### PR TITLE
Fix: Correct shebang and ensure proper entrypoint execution

### DIFF
--- a/backend/run-migrations.sh
+++ b/backend/run-migrations.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 echo "=== INICIANDO SCRIPT DE MIGRACIÓN DE BASE DE DATOS ==="
 


### PR DESCRIPTION
The container was failing to start due to a 'not found' error when executing `./run-migrations.sh`. The root cause was that the script's shebang was `#!/bin/bash`, but the minimal Alpine Docker image does not include `bash`, only `sh`.

This commit changes the shebang in `run-migrations.sh` to `#!/bin/sh`, which is compatible with the script's commands and available in the container.

This also includes the previous fix of adding `cd "$(dirname "$0")"` to `docker-entrypoint.sh` to ensure it runs from its own directory, making the script execution robust.