### PR TITLE
Fix(comments): Prevent autoscroll while typing or scrolled up

### DIFF
--- a/components/comments/CommentInput.tsx
+++ b/components/comments/CommentInput.tsx
@@ -6,13 +6,15 @@ interface CommentInputProps {
   isSubmitting?: boolean;
   placeholder?: string;
   disabled?: boolean;
+  onIsTypingChange?: (isTyping: boolean) => void;
 }
 
 const CommentInput: React.FC<CommentInputProps> = ({ 
   onSubmit, 
   isSubmitting = false,
   placeholder = "Escribe un comentario...",
-  disabled = false
+  disabled = false,
+  onIsTypingChange
 }) => {
   const [message, setMessage] = useState('');
   const [isExpanded, setIsExpanded] = useState(false);
@@ -42,12 +44,14 @@ const CommentInput: React.FC<CommentInputProps> = ({
 
   const handleFocus = () => {
     setIsExpanded(true);
+    onIsTypingChange?.(true);
   };
 
   const handleBlur = () => {
     if (!message.trim()) {
       setIsExpanded(false);
     }
+    onIsTypingChange?.(false);
   };
 
   return (

--- a/components/comments/CommentSystem.tsx
+++ b/components/comments/CommentSystem.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useRef } from 'react';
 import { Comment, CommentFormData } from '../../types/comments';
 import { useComments } from '../../hooks/useComments';
 import { useAuth } from '../../contexts/AuthContext';
@@ -24,6 +24,8 @@ const CommentSystem: React.FC<CommentSystemProps> = ({
   isConnected = false
 }) => {
   const { user } = useAuth();
+  const [isTyping, setIsTyping] = useState(false);
+  const listRef = useRef<{ scrollToBottom: (behavior?: ScrollBehavior) => void }>(null);
   
   const { 
     comments, 
@@ -40,6 +42,7 @@ const CommentSystem: React.FC<CommentSystemProps> = ({
     }
     
     await addComment(data.message);
+    listRef.current?.scrollToBottom('smooth');
   };
 
   const handleDeleteComment = async (commentId: string) => {
@@ -83,11 +86,13 @@ const CommentSystem: React.FC<CommentSystemProps> = ({
       {/* Comments List - Takes all available space */}
       <div className="flex-1 min-h-0">
         <CommentList
+          ref={listRef}
           comments={comments}
           currentUserId={currentUserId}
           canDeleteComments={canDeleteComments}
           onDeleteComment={handleDeleteComment}
           isLoading={isLoading}
+          isTyping={isTyping}
         />
       </div>
 
@@ -98,6 +103,7 @@ const CommentSystem: React.FC<CommentSystemProps> = ({
           isSubmitting={isSubmitting}
           placeholder="Escribe una actividad o comentario..."
           disabled={!currentUserId || !currentUserRole}
+          onIsTypingChange={setIsTyping}
         />
       )}
 


### PR DESCRIPTION
Implements a more intelligent scrolling mechanism in the comments panel to prevent automatic scrolling from disrupting the user.

The new logic is as follows:
- The panel no longer autoscrolls when the user is typing in the input field.
- The panel does not autoscroll if a new message arrives and the user is scrolled up, reading the history.
- The panel will only autoscroll if a new message arrives and the user is already at the bottom of the list.
- After sending a message, the panel will always scroll to the bottom to show the newly sent message.

This was achieved by lifting the 'isTyping' state, using `useLayoutEffect` to check the scroll position before DOM updates, and using a ref with `useImperativeHandle` to allow the parent component to force a scroll after a message is sent.