### PR TITLE
fix(comments): Refactor comment list to fix scrolling and ordering

### DIFF
--- a/components/PedidoModal.tsx
+++ b/components/PedidoModal.tsx
@@ -68,6 +68,16 @@ const PedidoModal: React.FC<PedidoModalProps> = ({ pedido, onClose, onSave, onAr
         setFormData(JSON.parse(JSON.stringify(pedido)));
     }, [pedido]);
 
+    // Efecto para controlar el scroll del body
+    useEffect(() => {
+        const originalStyle = window.getComputedStyle(document.body).overflow;
+        document.body.style.overflow = 'hidden';
+
+        return () => {
+            document.body.style.overflow = originalStyle;
+        };
+    }, []);
+
     // Manejar tecla Escape
     useEffect(() => {
         const handleEscapeKey = (event: KeyboardEvent) => {

--- a/components/comments/CommentSystem.tsx
+++ b/components/comments/CommentSystem.tsx
@@ -25,7 +25,6 @@ const CommentSystem: React.FC<CommentSystemProps> = ({
 }) => {
   const { user } = useAuth();
   const [isTyping, setIsTyping] = useState(false);
-  const listRef = useRef<{ scrollToBottom: (behavior?: ScrollBehavior) => void }>(null);
   
   const { 
     comments, 
@@ -42,7 +41,6 @@ const CommentSystem: React.FC<CommentSystemProps> = ({
     }
     
     await addComment(data.message);
-    listRef.current?.scrollToBottom('smooth');
   };
 
   const handleDeleteComment = async (commentId: string) => {
@@ -86,7 +84,6 @@ const CommentSystem: React.FC<CommentSystemProps> = ({
       {/* Comments List - Takes all available space */}
       <div className="flex-1 min-h-0">
         <CommentList
-          ref={listRef}
           comments={comments}
           currentUserId={currentUserId}
           canDeleteComments={canDeleteComments}


### PR DESCRIPTION
The comment list in the order modal had two issues:
1. New comments would appear, but the view would not scroll down, hiding the latest messages.
2. The comment order was chronological, but the UI did not feel like a standard chat interface.

This commit refactors the `CommentList` component to use a `flex-col-reverse` layout. This is a robust, CSS-based solution that anchors the content to the bottom of the container, ensuring new comments are always visible without manual scrolling logic.

- Changed the `CommentList` container to `flex flex-col-reverse`.
- Reversed the sort order of comments and date groups to maintain chronological appearance.
- Removed ~50 lines of complex and buggy `useEffect`/`useLayoutEffect` scroll-handling logic.
- Removed the unnecessary `ref` from `CommentSystem` that was used to trigger scrolling.

fix(ui): Prevent background scroll when modal is open

When the order modal was open, the main body of the page could still be scrolled in the background.

This commit adds a `useEffect` hook to the `PedidoModal` component. It sets the `overflow` style on the `<body>` to `hidden` when the modal mounts and restores the original style on unmount. This is a standard practice to prevent background scrolling and improve the user experience.